### PR TITLE
Append -java to container image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Alternatively, you can clone the [cloudstateio/samples-ui-shoppingcart](https://
 
 ### Shopping cart service
 
-You can use the pre-built `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest` container image available at Lightbend Cloudstate samples repository.
+You can use the pre-built `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java:latest` container image available at Lightbend Cloudstate samples repository.
 
 Alternatively, you can build an image from the sources in the `shopping-cart` directory and push it to your own container image repository.
 
@@ -42,8 +42,8 @@ jib {
     image = "adoptopenjdk/openjdk8:debian"
   }
   to {
-    image = "<my-registry>/shopping-cart"
-    tags = ["latest"]
+    image = "<my-registry>/shopping-cart-java"
+    tags = [version]
   }
   container {
     mainClass = "io.cloudstate.samples.shoppingcart.Main"
@@ -134,13 +134,13 @@ Proceed when `STATUS` is `ready`, this can take some time.
 
 ### Deploying the shopping cart service
 
-A pre-build container image of the frontend service is provided as `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart`.
+A pre-build container image of the shopping cart service is provided as `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java`.
 If you have built your own container image, change the image in the following command to point to the one that you just pushed.
 
 ```shell
 $ csctl svc deploy \
     shopping-cart \
-    lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart \
+    lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java \
     --with-store shopping-store
 ```
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,7 +35,7 @@ metadata:
   name: frontend
 spec:
   containers:
-  - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest # <-- Change this to your repo/image
+  - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java:latest # <-- Change this to your repo/image
     name: frontend
 ```
 

--- a/deploy/shopping-cart.yaml
+++ b/deploy/shopping-cart.yaml
@@ -11,5 +11,5 @@ spec:
       # Name of a deployed Datastore to use.
       name: shopping-store
   containers:
-    - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest
+    - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java:latest
       name: shopping-cart

--- a/shopping-cart/build.gradle
+++ b/shopping-cart/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.example"
-version = "0.1"
+version = "0.1.0"
 
 dependencies {
   implementation "io.cloudstate:cloudstate-java-support:0.4.7"
@@ -32,8 +32,8 @@ jib {
     image = "adoptopenjdk/openjdk8:debian"
   }
   to {
-    image = "lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart"
-    tags = ["java-" + version]
+    image = "lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java"
+    tags = [version]
   }
   container {
     mainClass = "io.cloudstate.samples.shoppingcart.Main"


### PR DESCRIPTION
Change the container image name to `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-java` to distinguish it from other shopping cart samples.